### PR TITLE
Refactor: View data migration

### DIFF
--- a/BaseApp/script/03-CAN_Tabla.sql
+++ b/BaseApp/script/03-CAN_Tabla.sql
@@ -124,22 +124,25 @@ CREATE TABLE dbo.Homologacion (
 );
 
 CREATE TABLE dbo.HomologacionEsquema(
-	 IdHomologacionEsquema     	INT IDENTITY(1,1) NOT NULL
-    ,MostrarWebOrden			INT DEFAULT(1) NOT NULL
-    ,MostrarWeb					NVARCHAR(200) NOT NULL DEFAULT('GRILLA')
+	IdHomologacionEsquema     	INT IDENTITY(1,1) NOT NULL
+  ,MostrarWebOrden			INT DEFAULT(1) NOT NULL
+  ,MostrarWeb					NVARCHAR(200) NOT NULL DEFAULT('GRILLA')
 	,TooltipWeb					NVARCHAR(200) NOT NULL DEFAULT('')
-    ,EsquemaJson				NVARCHAR(max) NOT NULL DEFAULT('{}')
-    ,VistaNombre				NVARCHAR(200) NOT NULL DEFAULT('')
+  ,EsquemaJson				NVARCHAR(max) NOT NULL DEFAULT('{}')
+  ,DataTipo				NVARCHAR(15) NOT NULL DEFAULT('NO_DEFINIDO') 
+  ,VistaNombre				NVARCHAR(200) NOT NULL DEFAULT('')
+  ,IdVistaNombre      NVARCHAR(200) NOT NULL DEFAULT('')
 	,Estado						NVARCHAR(1) NOT NULL DEFAULT('A')
 	,FechaCreacion				DATETIME	NOT NULL DEFAULT(GETDATE())
-    ,FechaModifica				DATETIME	NOT NULL DEFAULT(GETDATE())  
-    ,IdUserCreacion				INT			NOT NULL DEFAULT(0)
-    ,IdUserModifica				INT			NOT NULL DEFAULT(0)  
+  ,FechaModifica				DATETIME	NOT NULL DEFAULT(GETDATE())  
+  ,IdUserCreacion				INT			NOT NULL DEFAULT(0)
+  ,IdUserModifica				INT			NOT NULL DEFAULT(0)  
 
-    ,CONSTRAINT  [PK_HE_IdHomologacionEsquema]	PRIMARY KEY CLUSTERED (IdHomologacionEsquema) 
-    ,CONSTRAINT  [CK_HE_EsquemaJson]			CHECK   (ISJSON(EsquemaJson) = 1 )
-    ,CONSTRAINT  [CK_HE_Estado]				    CHECK   (Estado IN ('A', 'X'))
-     --,CONSTRAINT  UK_HE_VistaNombre		        UNIQUE (VistaNombre)
+  ,CONSTRAINT  [PK_HE_IdHomologacionEsquema]	PRIMARY KEY CLUSTERED (IdHomologacionEsquema) 
+  ,CONSTRAINT  [CK_HE_EsquemaJson]			CHECK   (ISJSON(EsquemaJson) = 1 )
+  ,CONSTRAINT  [CK_HE_Estado]				    CHECK   (Estado IN ('A', 'X'))
+	,CONSTRAINT  [UK_HE_DataTipo]	CHECK (DataTipo IN ('ORGANIZACION', 'PERSONA','NO_DEFINIDO'))
+  --,CONSTRAINT  UK_HE_VistaNombre		        UNIQUE (VistaNombre)
 );
 
 CREATE TABLE dbo.DataLake(
@@ -159,6 +162,8 @@ CREATE TABLE dbo.DataLake(
 CREATE TABLE dbo.DataLakeOrganizacion(
      IdDataLakeOrganizacion INT IDENTITY(1,1) NOT NULL
     ,IdHomologacionEsquema	INT NOT NULL  --FOREIGN KEY REFERENCES HomologacionEsquema (IdHomologacionEsquema)
+    ,IdOrganizacion			NVARCHAR(200) NOT NULL DEFAULT('')
+    ,IdVista            NVARCHAR(200) NOT NULL DEFAULT('')
     ,IdDataLake				INT NOT NULL  FOREIGN KEY REFERENCES DataLake (IdDataLake)
     ,DataEsquemaJson        NVARCHAR(max) NOT NULL DEFAULT('{}')
     ,DataFechaCarga			DATETIME	  NOT NULL DEFAULT(GETDATE())
@@ -205,17 +210,18 @@ CREATE TABLE dbo.Conexion (
     ,MotorBaseDatos     NVARCHAR(100) NOT NULL
     ,Filtros            NVARCHAR(MAX) NOT NULL DEFAULT('{}')
     ,FechaConexion		DATETIME NOT NULL DEFAULT(GETDATE())
-    ,TiempoEspera       INT NOT NULL DEFAULT(0) -- Tiempo de espera en segundos
-
-    ,Estado			    NVARCHAR(1) NOT NULL DEFAULT('A')
-    ,FechaCreacion		DATETIME	NOT NULL DEFAULT(GETDATE())
-    ,FechaModifica		DATETIME	NOT NULL DEFAULT(GETDATE())  
-    ,IdUserCreacion		INT			NOT NULL DEFAULT(0)
-    ,IdUserModifica		INT			NOT NULL DEFAULT(0)  
+    ,TiempoEspera    INT NOT NULL DEFAULT(0) -- Tiempo de espera en segundos
+    ,Migrar         NVARCHAR(1) NOT NULL DEFAULT('S') -- N= No migrar, S= Si migrar
+    ,Estado			NVARCHAR(1) NOT NULL DEFAULT('A')
+    ,FechaCreacion				DATETIME	NOT NULL DEFAULT(GETDATE())
+    ,FechaModifica				DATETIME	NOT NULL DEFAULT(GETDATE())  
+    ,IdUserCreacion				INT			NOT NULL DEFAULT(0)
+    ,IdUserModifica				INT			NOT NULL DEFAULT(0)  
   
     ,CONSTRAINT  [PK_C_IdConexion]		    PRIMARY KEY CLUSTERED (IdConexion) 
     ,CONSTRAINT  [FK_C_IdUsuario]		    FOREIGN KEY (IdUsuario) REFERENCES Usuario(IdUsuario)
     ,CONSTRAINT  [CK_C_Estado]			    CHECK   (Estado IN ('A', 'X'))
+    ,CONSTRAINT  [CK_C_Migrar]			    CHECK   (Migrar IN ('S', 'N'))
     ,CONSTRAINT  [CK_C_MotorBaseDatos]  CHECK   (MotorBaseDatos IN ('MYSQL', 'SQLSERVER', 'SQLLITE'))
     ,CONSTRAINT  [CK_C_Filtros]			CHECK   (ISJSON(Filtros) = 1 )
 );

--- a/SharedApp/Models/Dtos/DataLakeOrganizacionDto.cs
+++ b/SharedApp/Models/Dtos/DataLakeOrganizacionDto.cs
@@ -5,6 +5,8 @@
     public int IdDataLakeOrganizacion { get; set; }
     public int? IdHomologacionSistema { get; set; }
     public int? IdDataLake { get; set; }
+    public string? IdOrganizacion { get; set; }
+    public string? IdVista { get; set; }
     public string? DataEsquemaJson { get; set; }
     public string? Estado { get; set; }
     public bool? Activo { get; set; }

--- a/SharedApp/Models/Dtos/HomologacionEsquemaDto.cs
+++ b/SharedApp/Models/Dtos/HomologacionEsquemaDto.cs
@@ -5,6 +5,7 @@ namespace SharedApp.Models.Dtos
   public class HomologacionEsquemaDto
   {
     public int IdHomologacionEsquema { get; set; }
+    public int IdVistaNombre { get; set; }
     [Required]
     public string? EsquemaJson { get; set; }
     [Required]
@@ -15,5 +16,6 @@ namespace SharedApp.Models.Dtos
     public string? TooltipWeb { get; set; }
     [Required]
     public string? VistaNombre { get; set; }
+    public string? DataTipo { get; set; }
   }
 }

--- a/WebApp/Models/Conexion.cs
+++ b/WebApp/Models/Conexion.cs
@@ -16,4 +16,5 @@ public class Conexion : BaseEntity
     public string? Filtros { get; set; }
     public DateTime? FechaConexion { get; set; }
     public int TiempoEspera { get; set; }
+    public string? Migrar { get; set; }
 }

--- a/WebApp/Models/DataLakeOrganizacion.cs
+++ b/WebApp/Models/DataLakeOrganizacion.cs
@@ -7,6 +7,8 @@ public class DataLakeOrganizacion
     public int IdDataLakeOrganizacion { get; set; }
     public int? IdHomologacionEsquema { get; set; }
     public int? IdDataLake { get; set; }
+    public string? IdOrganizacion { get; set; }
+    public string? IdVista { get; set; }
     public string? DataEsquemaJson { get; set; }
     public string? Estado { get; set; }
 }

--- a/WebApp/Models/HomologacionEsquema.cs
+++ b/WebApp/Models/HomologacionEsquema.cs
@@ -9,6 +9,7 @@ namespace WebApp.Models
     [Key]
     [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
     public int IdHomologacionEsquema { get; set; }
+    public string IdVistaNombre { get; set; }
     [Required]
     public string? EsquemaJson { get; set; }
     [Required]
@@ -17,6 +18,7 @@ namespace WebApp.Models
     public string? MostrarWeb { get; set; }
     [Required]
     public string? VistaNombre { get; set; }
+    public string? DataTipo { get; set; }
     public string? TooltipWeb { get; set; }
   }
 }

--- a/WebApp/Models/OrganizacionFullText.cs
+++ b/WebApp/Models/OrganizacionFullText.cs
@@ -5,7 +5,7 @@ public class OrganizacionFullText
 {
     [Key]
     public int IdOrganizacionFullText { get; set; }
-    public int? IdDataLakeOrganizacion { get; set; }
+    public int IdDataLakeOrganizacion { get; set; }
     public int? IdHomologacion { get; set; }
     public string? FullTextOrganizacion { get; set; }
 }

--- a/WebApp/Repositories/DataLakeOrganizacionRepository.cs
+++ b/WebApp/Repositories/DataLakeOrganizacionRepository.cs
@@ -59,20 +59,21 @@ namespace WebApp.Repositories
     {
       return ExecuteDbOperation(context => {
         var records = context.DataLakeOrganizacion.Where(c => c.IdHomologacionEsquema == IdHomologacionEsquema).ToList();
-        var deletedRecordIds = new List<int?>();
+        List<int> deletedRecordIds = records.Select(r => r.IdDataLakeOrganizacion).ToList();
 
-        foreach (var record in records)
-        {
-          record.Estado = "X";
-          deletedRecordIds.Add(record.IdDataLakeOrganizacion);
-        }
-
-        context.DataLakeOrganizacion.UpdateRange(records);
-        context.SaveChanges();
+        // foreach (var record in records)
+        // {
+        //   record.Estado = "X";
+        //   deletedRecordIds.Add(record.IdDataLakeOrganizacion);
+        // }
+        // context.DataLakeOrganizacion.UpdateRange(records);
+        // context.SaveChanges();
 
         var deletedOrganizacionFullTextRecords = context.OrganizacionFullText.Where(o => deletedRecordIds.Contains(o.IdDataLakeOrganizacion)).ToList();
-        Console.WriteLine($"Deleted OrganizacionFullText records: {deletedOrganizacionFullTextRecords.Count}");
         context.OrganizacionFullText.RemoveRange(deletedOrganizacionFullTextRecords);
+        context.SaveChanges();
+
+        context.DataLakeOrganizacion.RemoveRange(records);
         context.SaveChanges();
 
         return true;

--- a/WebApp/Service/ConectionStringBuilderService.cs
+++ b/WebApp/Service/ConectionStringBuilderService.cs
@@ -19,14 +19,13 @@ namespace WebApp.Service
 
         string BuildMysqlConnectionString(Conexion conexion)
         {
-            return $"Server={conexion.Host};Port={conexion.Puerto};Database={conexion.BaseDatos};Uid={conexion.Usuario};Pwd={conexion.Contrasenia};";
+          return $"Server={conexion.Host};Port={conexion.Puerto};Database={conexion.BaseDatos};Uid={conexion.Usuario};Pwd={conexion.Contrasenia};";
         }
 
         string BuildSqlServerConnectionString(Conexion conexion)
         {
-            // return $"Server={conexion.Host},{conexion.Puerto};Database={conexion.BaseDatos};User Id={conexion.Usuario};Password={conexion.Contrasenia};TrustServerCertificate=True;";
-            return $"Server={conexion.Host};Initial Catalog={conexion.BaseDatos};User ID={conexion.Usuario};Password={conexion.Contrasenia};TrustServerCertificate=True;";
-            // "Server=PAT-PC;Initial Catalog=CAN_DB;User ID=pat_mic;Password=michael;TrustServerCertificate=True"
+          string portString = conexion.Puerto != 0 ? $",{conexion.Puerto}" : "";
+          return $"Server={conexion.Host}{portString};Database={conexion.BaseDatos};User Id={conexion.Usuario};Password={conexion.Contrasenia};TrustServerCertificate=True;";
         }
 
         string BuildSqliteConnectionString(Conexion conexion)


### PR DESCRIPTION
Agrega IdOrganizacion a DataLakeOrganizacion para saber a que organización pertenece cada registro
Agrega IdVista a DataLakeOrganizacion para saber a que organización pertenece cada registro
Agrega DataTipo a HomologacionEquema para saber el tipo de esquema que se está migrando
Agrega IdVistaNombre a HomologacionEquema para saber el nombre del campo de identificación único de la vista

Refactora la migración de datos desde vistas para considerar nuevas validaciones y guardar los identificadores únicos de registros de las vistas al igual que el identificador único de la organización a la que pertenece cada registro.